### PR TITLE
Fix emitting empty PostData

### DIFF
--- a/har.go
+++ b/har.go
@@ -104,7 +104,7 @@ type Request struct {
 	Cookies     []Cookie      `json:"cookies"`
 	Headers     []Header      `json:"headers"`
 	QueryString []QueryString `json:"queryString"`
-	PostData    PostData      `json:"postData,omitempty"`
+	PostData    *PostData      `json:"postData,omitempty"`
 	HeadersSize int           `json:"headersSize"`
 	BodySize    int           `json:"bodySize"`
 	Comment     string        `json:"comment,omitempty"`


### PR DESCRIPTION
postData is always emitted and http://www.softwareishard.com/har/viewer/ validator complaints "log.entries[0].request.postData.params |   |   | object value found, but a array is required"
