### PR TITLE
Skip nil postdata when making request

### DIFF
--- a/har.go
+++ b/har.go
@@ -113,7 +113,11 @@ type Request struct {
 // Convert a HAR Request struct to an net/http.Request struct
 func (r *Request) Request() (httpreq *http.Request, err error) {
 
-	dstr := r.PostData.Data()
+	var dstr string
+	if r.PostData != nil {
+		dstr = r.PostData.Data()
+	}
+
 	if len(dstr) > 0 {
 		var body *strings.Reader
 		body = strings.NewReader(dstr)


### PR DESCRIPTION
#2 allowed postdata to be nil, but this method assumed non-nil postdata. i'm pretty new to go, so please let me know if there's a more idiomatic way to phrase this.